### PR TITLE
zephyr: update include paths to use <zephyr/...>

### DIFF
--- a/altera_hal/HAL/src/altera_common.c
+++ b/altera_hal/HAL/src/altera_common.c
@@ -74,7 +74,7 @@ int alt_dev_llist_insert (alt_dev_llist* dev, alt_llist* list)
 }
 
 #include "priv/alt_busy_sleep.h"
-#include <kernel.h>
+#include <zephyr/kernel.h>
 unsigned int alt_busy_sleep (unsigned int us)
 {
 	k_busy_wait(us);


### PR DESCRIPTION
Zephyr has prefixed all of its includes with <zephyr/...>. While the old
mode can still be used (CONFIG_LEGACY_INCLUDE_PATH) and is still enabled
by default, it's better to be prepared for its removal in the future.