### PR TITLE
uart: do not build hal uart driver

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,19 +24,6 @@ if (CONFIG_HAS_ALTERA_HAL)
     add_subdirectory(drivers/altera_avalon_sysid/HAL/src)
   endif()
 
-  if(CONFIG_UART_ALTERA_JTAG)
-    zephyr_compile_definitions(ALTERA_AVALON_JTAG_UART_SMALL)
-    zephyr_include_directories(
-      drivers/altera_avalon_jtag_uart/inc
-      drivers/altera_avalon_jtag_uart/HAL/inc
-      drivers/altera_avalon_jtag_uart/LWHAL/inc
-      )
-    add_subdirectory(
-      drivers/altera_avalon_jtag_uart/HAL/src
-      drivers/altera_avalon_jtag_uart/LWHAL/src
-      )
-  endif()
-
   if(CONFIG_ALTERA_AVALON_MSGDMA)
     zephyr_include_directories(
       drivers/altera_msgdma/inc


### PR DESCRIPTION
We use in-tree driver instead.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
