### PR TITLE
drivers: jtag_uart: use zephyr/posix prefix for posix headers

### DIFF
--- a/drivers/altera_avalon_jtag_uart/HAL/src/altera_avalon_jtag_uart_init.c
+++ b/drivers/altera_avalon_jtag_uart/HAL/src/altera_avalon_jtag_uart_init.c
@@ -27,11 +27,11 @@
 ******************************************************************************/
 
 #include <string.h>
-#include <fcntl.h>
+#include <zephyr/posix/fcntl.h>
 #include <errno.h>
 #include <limits.h>
 
-#include <sys/stat.h>
+#include <zephyr/posix/sys/stat.h>
 
 #include "sys/alt_irq.h"
 #include "sys/alt_alarm.h"

--- a/drivers/altera_avalon_jtag_uart/HAL/src/altera_avalon_jtag_uart_ioctl.c
+++ b/drivers/altera_avalon_jtag_uart/HAL/src/altera_avalon_jtag_uart_ioctl.c
@@ -27,11 +27,11 @@
 ******************************************************************************/
 
 #include <string.h>
-#include <fcntl.h>
+#include <zephyr/posix/fcntl.h>
 #include <errno.h>
 #include <limits.h>
 
-#include <sys/stat.h>
+#include <zephyr/posix/sys/stat.h>
 
 #include "sys/ioctl.h"
 #include "alt_types.h"

--- a/drivers/altera_avalon_jtag_uart/HAL/src/altera_avalon_jtag_uart_read.c
+++ b/drivers/altera_avalon_jtag_uart/HAL/src/altera_avalon_jtag_uart_read.c
@@ -27,11 +27,11 @@
 ******************************************************************************/
 
 #include <string.h>
-#include <fcntl.h>
+#include <zephyr/posix/fcntl.h>
 #include <errno.h>
 #include <limits.h>
 
-#include <sys/stat.h>
+#include <zephyr/posix/sys/stat.h>
 
 #include "sys/alt_irq.h"
 #include "sys/alt_alarm.h"

--- a/drivers/altera_avalon_jtag_uart/HAL/src/altera_avalon_jtag_uart_write.c
+++ b/drivers/altera_avalon_jtag_uart/HAL/src/altera_avalon_jtag_uart_write.c
@@ -27,11 +27,11 @@
 ******************************************************************************/
 
 #include <string.h>
-#include <fcntl.h>
+#include <zephyr/posix/fcntl.h>
 #include <errno.h>
 #include <limits.h>
 
-#include <sys/stat.h>
+#include <zephyr/posix/sys/stat.h>
 
 #include "sys/alt_irq.h"
 #include "sys/alt_alarm.h"


### PR DESCRIPTION
Approximately 2 and 1/2 years ago, Zephyr switched to requiring a prefix of `<zephyr/posix/..>` for standard posix headers.

It would seem as though the altera hal is unmaintained and nobody bothered to update it.

Note: It is advisable to not use POSIX within drivers since it creates a dependency cycle, so this is still somewhat broken. Additionally, trying to use POSIX features without enabling POSIX is probably a slippery slope.

This fixes a build failure due to lack of maintenance, and the recent removal of deprecated headers in https://github.com/zephyrproject-rtos/zephyr/pull/75775

Fixes zephyrproject-rtos/zephyr#75837 (a workaround really... a better solution would not be to use POSIX below the line).